### PR TITLE
Release 2.0

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -11,6 +11,7 @@ on:
       - 'main'
   schedule:
     - cron: '0 10 25 * *' # Monthly at 10am on the 25th
+  workflow_dispatch:
 
 jobs:
   build:
@@ -35,7 +36,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.0.') }}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=sha
-      - name: Set up QEMU for cross-build
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # docker-sqitch-pgtap Changelog
 
+## 2.0.0 / 2022-08-23
+
+- Update base alpine version to 3.16. Made the use of alpine 3.16 explicit in
+  the specification of the PostgreSQL versions in the docker file.
+
+- Update tool versions:
+
+  - pgTAP 1.2.1+ (from git)
+  - pg_prove 3.36 (`TAP::Parser::SourceHandler::pgTAP`)
+  - sqitch 1.3.0 (`App::Sqitch`)
+
+- Added PostgreSQL 15 beta 3.
+
+- Removed PostgreSQL 9.6.
+
+- Backported several changes to the `run` script made during the full adoption
+  of this image and run script internally at Kinetic.
+
+  - Add a way of getting the current Docker context so that when running under
+    `colima`, the appropriate internal host name can be used to reach a database
+    on the host server.
+
+  - Fix a bug where `date +%Z` does not work on Linux the way it does on macOS.
+    Always default to a timezone of `Etc/UTC`.
+
+  - Map the user by ID into the docker image to prevent file read, write, or
+    cleanup issues.
+
+  - Remove deprecated commands.
+
+  - Standardize `structure.sql` cleaning.
+
+  - Improve `structure.sql` comparison and report when there are no
+    differences in the database structure.
+
+- Changed all `scripts/*` files from `/bin/sh` to `/bin/bash`.
+
 ## 1.1.0 / 2021-12-14
 
 - Update base alpine version to 3.15
@@ -10,8 +47,8 @@
   - pg_prove 3.35 (`TAP::Parser::SourceHandler::pgTAP`)
   - sqitch 1.2.1 (`App::Sqitch`)
 
-- Added postgres 14. Please note that postgres 9.6 has reached end-of-life, and
-  will be removed in a future version.
+- Added PostgreSQL 14. Please note that PostgreSQL 9.6 has reached end-of-life,
+  and will be removed in a future version.
 
 ## 1.0.1 / 2021-06-16
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ variables or on the command-line.
 
 This version of the container includes:
 
-- pgTAP 1.2.0
-  - Support for PostgreSQL 9.6, 10, 11, 12, 13, and 14
+- pgTAP 1.2.1 (via git, as 1.2.1 has not been released)
+  - Support for PostgreSQL 10, 11, 12, 13, and 14
+  - Support for PostgreSQL 15 beta 3
 - pg_prove 3.36
-- Sqitch 1.2.1
+- Sqitch 1.3.0
 
-The version of pgTAP is installed and uninstalled as needed; the unit test files
+The version of pgTAP is installed and uninstalled as needed; unit test files
 must _not_ `CREATE EXTENSION pgtap`.
 
 ## `run` script Commands

--- a/run
+++ b/run
@@ -37,6 +37,11 @@ has() {
   builtin command -v "${@}" >/dev/null
 }
 
+get-current-docker-context() {
+  docker context ls --format '{{ . | json }}' |
+    jq -sr '.[] | select(.Current == true) | .Name'
+}
+
 set-command() {
   case "$1" in
   sh) cmd="$1" ;;
@@ -129,14 +134,19 @@ setup() {
   passopt=(
     -e "SQITCH_ORIG_SYSUSER=${user}"
     -e "SQITCH_ORIG_EMAIL=${user}@$(hostname)"
-    -e "TZ=$(date +%Z)"
+    -e "TZ=Etc/UTC"
     -e "LESS=${LESS:--R}"
     -e "HOME=${home_dest}"
   )
 
-  local var
+  local var docker_host
 
-  PGHOST="${PGHOST:-host.docker.internal}"
+  case "$(get-current-docker-context)" in
+  colima) docker_host="host.lima.internal" ;;
+  *) docker_host="host.docker.internal" ;;
+  esac
+
+  PGHOST="${PGHOST:-${docker_host}}"
   PGPORT="${PGPORT:-5432}"
 
   [[ "${uname_s}" == Darwin ]] && PGUSER="${PGUSER:-${USER}}"
@@ -185,16 +195,13 @@ run() {
 
   local v cmd
 
-  if ! set-command "$1"; then
-    echo "Unsupported run command '$1'."
-    exit 1
-  fi
-
+  set-command "$1" || fail "Unsupported run command '$1'."
   shift
 
   docker run -it --rm --network host \
     --mount "type=bind,src=$(pwd),dst=/repo" \
     --mount "type=bind,src=${HOME},dst=${home_dest},readonly" \
+    --user "$(id -u):$(id -g)" \
     "${passopt[@]}" "${image}" "${cmd}" "$@"
 }
 
@@ -202,10 +209,8 @@ get-sqitch-config() {
   local result
   result="$(run sqitch config "$@" | tr -d '\t\r\n')" ||
     fail $? "Result - [${result}]"
-  echo "${result}"
+  puts "${result}"
 }
-
-# These are commands publicly documented.
 
 usage() {
   puts <<-EOS
@@ -264,12 +269,7 @@ EOS
 }
 
 run-show-target() {
-  echo "${SQITCH_TARGET}"
-}
-
-run-show-default-target() {
-  echo >&2 "show-default-target is deprecated, use show-target instead"
-  run-show-target
+  puts "${SQITCH_TARGET}"
 }
 
 usage-show-dbname() {
@@ -281,12 +281,7 @@ EOS
 }
 
 run-show-dbname() {
-  echo "${SQITCH_DBNAME}"
-}
-
-run-show-default-dbname() {
-  echo >&2 "show-default-dbname is deprecated, use show-dbname instead"
-  run-show-dbname
+  puts "${SQITCH_DBNAME}"
 }
 
 usage-pgtap-tests() {
@@ -347,6 +342,12 @@ Options:
 EOS
 }
 
+clean-structure() {
+  cat "$1" |
+    sed -e '/Dumped from database version/d' |
+    sed -e '/Dumped by pg_dump version/d'
+}
+
 run-structure() {
   local dbname target clean compare arg need
   compare=false
@@ -382,19 +383,28 @@ run-structure() {
     if (($(psql --list | grep -c "${dbname}"))); then
       quiet must-run dropdb "${dbname}"
     fi
+
     quiet must-run createdb "${dbname}"
     quiet must-run sqitch deploy db:pg:"${dbname}"
   fi
 
+  [[ -z "${target}" ]] && target="${STRUCTURE_TARGET}"
+
   "${compare}" && target="${dbname}"
 
-  must-run pg_dump -s -O -x -d "${dbname}" | tr -d '\r' >"${target}"
+  must-run pg_dump -s -O -x -d "${dbname}" |
+    tr -d '\r' >"${target}"
 
   "${clean}" && quiet must-run dropdb "${dbname}"
 
   if "${compare}"; then
-    [[ x"${CI}" = x ]] || PAGER=
-    diff -u "${STRUCTURE_TARGET}" "${target}"
+    [[ -z "${CI}" ]] && PAGER=
+
+    diff -u \
+      <(clean-structure "${STRUCTURE_TARGET}") \
+      <(clean-structure "${target}") &&
+      puts "No differences in database structure."
+
     rm -f "${target}"
   fi
 }

--- a/scripts/do_nano
+++ b/scripts/do_nano
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 cd /repo || {
   echo "Error changing to /repo"

--- a/scripts/do_pg_prove
+++ b/scripts/do_pg_prove
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 cd /repo || {
   echo "Error changing to /repo"

--- a/scripts/do_pgtap
+++ b/scripts/do_pgtap
@@ -1,13 +1,13 @@
-#! /bin/sh
+#! /bin/bash
 
-if [ -z "$1" ]; then
+if [[ -z "$1" ]]; then
   echo >&2 "No subcommand provided."
   exit 1
 fi
 
 psql_server_version() {
   db="${PGDATABASE}"
-  [ -z "${db}" ] && db=postgres
+  [[ -z "${db}" ]] && db=postgres
   psql -q "${db}" -c '\t on' -c 'show server_version;'
 }
 
@@ -27,20 +27,28 @@ uninstall_pgtap() {
 }
 
 cd /repo || {
-  echo "Error changing to /repo"
+  echo >&2 "Error changing to /repo"
   exit 1
 }
 
 version=$(psql_server_version | tr -d ' \t\n\v\r')
 
 case "${version}" in
-9.6*) version=9 ;;
+9.6*)
+  cat >&2 <<ERROR
+Unsupported version of PostgreSQL 9.6. If PostgreSQL 9.6 is still required, use
+image kineticcafe/sqitch-pgtap:1.1.0.
+ERROR
+  exit 1
+  ;;
 10*) version=10 ;;
 11*) version=11 ;;
 12*) version=12 ;;
 13*) version=13 ;;
+14*) version=14 ;;
+15*) version=15 ;; # This is beta support
 *)
-  echo "Unknown or unsupported PostgreSQL version '${version}'."
+  echo >&2 "Unknown or unsupported PostgreSQL version '${version}'."
   exit 1
   ;;
 esac

--- a/scripts/do_version
+++ b/scripts/do_version
@@ -1,7 +1,7 @@
-#! /bin/sh
+#! /bin/bash
 
 cat <<EOS
-kineticcafe/sqitch-pgtap:${__DOCKERFILE_VERSION__}
+kineticcafe/sqitch-pgtap:$(cat /home/sqitch/VERSION)
 
   $(sqitch --version)
   pgtap ${PGTAP_VERSION}


### PR DESCRIPTION
Technical Change Notes
======================

- Backport several changes made during the full adoption of
  docker-sqitch-pgtap internally at Kinetic. The changes were entirely
  to the `run` script.

  - Add a way of getting the current Docker context so that when running
    under `colima`, the appropriate internal host name can be used to
    reach a database on the host server.

  - Fix a bug where `date +%Z` does not work on Linux the way it does on
    macOS. Always default to a timezone of `Etc/UTC`.

  - Map the user by ID into the docker image to prevent file read, write,
    or cleanup issues.

  - Remove deprecated commands.

  - Standardize `structure.sql` cleaning.

  - Improve `structure.sql` comparison and report when there are no
    differences in the database structure.

- Change all `scripts/*` files from `/bin/sh` to `/bin/bash`.

- Add support for PostgreSQL 15 beta 3.

- Remove support for PostgreSQL 9.6.

- Made the PostgreSQL alpine version explicit.

- Update to pg_prove 3.36, pgtap 1.2.1+ (from git), and sqitch 1.3.0.