### PR TITLE
Update run script to use latest version 2

### DIFF
--- a/run
+++ b/run
@@ -9,7 +9,7 @@ declare SQITCH_DBNAME SQITCH_TARGET cmd home_dest image uname_s user
 declare -a passopt
 
 declare STRUCTURE_TARGET TIMESTAMP bn0 DEFAULT_IMAGE
-DEFAULT_IMAGE=ghcr.io/kineticcafe/sqitch-pgtap:2.1
+DEFAULT_IMAGE=ghcr.io/kineticcafe/sqitch-pgtap:2
 bn0="$(basename "$0")"
 STRUCTURE_TARGET="${STRUCTURE_TARGET:-structure.sql}"
 TIMESTAMP="${TIMESTAMP:-"$(date -u +%Y%m%d%H%M%S)"}"


### PR DESCRIPTION
Technical Change Notes
======================

We released version 2.2 but didn't update the `run` script. This changes the `run` script to use version 2 (major only) so that such upgrades are automatically captured in the future.