### PR TITLE
v2.6: Upgrade Alpine, pgTAP, and Sqitch

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -36,6 +36,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - run: ./run version
+      - run: ./kineticcafe-sqitch-pgtap version
         env:
           IMAGE: kineticcafe/sqitch-pgtap:test

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,19 +11,6 @@ on:
         required: true
 
 jobs:
-  make-release:
-    runs-on: ubuntu-latest
-    name: Create Release
-    steps:
-      - uses: actions/checkout@v4
-        if: github.event_name == 'push'
-      - uses: actions/checkout@v4
-        if: github.event_name == 'workflow_dispatch'
-        with:
-          ref: refs/tags/${{ github.event.inputs.tag }}
-      - uses: ghalactic/github-release-from-tag@v5
-        with:
-          summaryEnabled: false
   publish-image:
     name: Build and Push to Docker Hub
     runs-on: ubuntu-latest
@@ -75,6 +62,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             ALPINE_VERSION=${{ fromJSON(steps.package-versions.outputs.data).alpine.version }}
             PGTAP_VERSION=${{ fromJSON(steps.package-versions.outputs.data).pgtap.version }}
@@ -87,6 +75,10 @@ jobs:
             linux/arm/v7
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - uses: ghalactic/github-release-from-tag@v5
+        with:
+          summaryEnabled: false
 
       - uses: peter-evans/dockerhub-description@v4.0.0
         with:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 # kineticcafe/sqitch-pgtap Changelog
 
+## 2.6.0 / 2024-02-27
+
+- Upgrade Sqitch to version [1.4.1][sqitch-1.4.1].
+
+- Upgrade Alpine to version [3.19][alpine-3.19].
+
+- Rename `run` to `kineticcafe-sqitch-pgtap`.
+
+- Added an `install` script to install `kineticcafe-sqitch-pgtap` and optional
+  symlinks.
+
 ## 2.5.1 / 2024-02-20
 
 - Upgrade pgTAP to 1.3.3 at
@@ -9,7 +20,7 @@
 
 ## 2.5.0 / 2023-09-27
 
-- Upgraded pgTAP to 1.3.1.
+- Upgraded pgTAP to [1.3.1][pgtap-1.3.1].
 
 - Update support for the released version of PostgreSQL 16.
 
@@ -23,13 +34,13 @@
 
 ## 2.4.0 / 2023-08-16
 
-- Upgraded pgTAP to 1.3.0.
+- Upgraded pgTAP to [1.3.0][pgtap-1.3.0].
 
 - Updated PostgreSQL 16 beta 2 to PostgreSQL beta 3
 
 ## 2.3.0 / 2023-08-03
 
-- Upgraded sqitch version to 1.4.0.
+- Upgraded Sqitch version to [1.4.0][sqitch-1.4.0].
 
 - Upgraded pgTAP to 1.2.1 at theory/pgtap@96a7a416311ea5f2fa140f59cfdf7c7afbded17c.
 
@@ -46,7 +57,7 @@
 - Extended Dependabot configuration to look at `build/pgtap/Dockerfile` as well
   as the root `Dockerfile.`
 
-- Upgraded base image to Alpine 3.18.
+- Upgraded base image to Alpine [3.18][alpine-3.18]
 
 - Added code to work around an unnecessary warning from `docker context ls` when
   `$DOCKER_HOST` is already set.
@@ -93,26 +104,26 @@
 
 - Update support for the released version of PostgreSQL 15.
 
-- Update base Alpine version to 3.17.
+- Update base Alpine version to [3.17][alpine-3.17]
 
-- Add GHCR publishing.
+- Add GitHub Container Repository publishing.
 
 ## 2.0.1 / 2022-10-04
 
-- Update sqitch version to 1.3.1.
+- Update Sqitch version to [1.3.1][sqitch-1.3.1]
 
 - Update PostgreSQL 15 to RC 1 from beta 3.
 
 ## 2.0.0 / 2022-08-23
 
-- Update base alpine version to 3.16. Made the use of alpine 3.16 explicit in
-  the specification of the PostgreSQL versions in the docker file.
+- Update base alpine version to [3.16][alpine-3.16] Made the use of alpine 3.16
+  explicit in the specification of the PostgreSQL versions in the docker file.
 
 - Update tool versions:
 
   - pgTAP 1.2.1+ (from git)
-  - pg_prove 3.36 (`TAP::Parser::SourceHandler::pgTAP`)
-  - sqitch 1.3.0 (`App::Sqitch`)
+  - pg_prove [3.36][pg_prove-3.36] (`TAP::Parser::SourceHandler::pgTAP`)
+  - Sqitch [1.3.0][sqitch-1.3.0] (`App::Sqitch`)
 
 - Added PostgreSQL 15 beta 3.
 
@@ -142,13 +153,13 @@
 
 ## 1.1.0 / 2021-12-14
 
-- Update base alpine version to 3.15
+- Update base alpine version to [3.15][alpine-3.15]
 
 - Update tool versions:
 
-  - pgTAP 1.2.0
-  - pg_prove 3.35 (`TAP::Parser::SourceHandler::pgTAP`)
-  - sqitch 1.2.1 (`App::Sqitch`)
+  - pgTAP [1.2.0][pgtap-1.2.0]
+  - pg_prove [3.35][pg_prove-3.35] (`TAP::Parser::SourceHandler::pgTAP`)
+  - Sqitch [1.2.1][sqitch-1.2.1] (`App::Sqitch`)
 
 - Added PostgreSQL 14. Please note that PostgreSQL 9.6 has reached end-of-life,
   and will be removed in a future version.
@@ -161,6 +172,21 @@
 
 - Initial released version.
 
-[extractions/setup-just]: https://github.com/extractions/setup-just
+[alpine-3.15]: https://hub.docker.com/_/alpine/tags?name=3.15
+[alpine-3.16]: https://hub.docker.com/_/alpine/tags?name=3.16
+[alpine-3.17]: https://hub.docker.com/_/alpine/tags?name=3.17
+[alpine-3.18]: https://hub.docker.com/_/alpine/tags?name=3.18
+[alpine-3.19]: https://hub.docker.com/_/alpine/tags?name=3.19
 [casey/just]: https://github.com/casey/just
+[extractions/setup-just]: https://github.com/extractions/setup-just
 [orbstack-internal]: https://docs.orbstack.dev/machines/network#connecting-to-servers-on-mac
+[pg_prove-3.35]: https://github.com/theory/tap-parser-sourcehandler-pgtap/releases/tag/v3.35
+[pg_prove-3.36]: https://github.com/theory/tap-parser-sourcehandler-pgtap/releases/tag/v3.36
+[pgtap-1.2.0]: https://github.com/theory/pgtap/releases/tag/v1.2.0
+[pgtap-1.3.0]: https://github.com/theory/pgtap/releases/tag/v1.3.0
+[pgtap-1.3.1]: https://github.com/theory/pgtap/releases/tag/v1.3.1
+[sqitch-1.2.1]: https://github.com/sqitchers/sqitch/releases/tag/v1.2.1
+[sqitch-1.3.0]: https://github.com/sqitchers/sqitch/releases/tag/v1.3.0
+[sqitch-1.3.1]: https://github.com/sqitchers/sqitch/releases/tag/v1.3.1
+[sqitch-1.4.0]: https://github.com/sqitchers/sqitch/releases/tag/v1.4.0
+[sqitch-1.4.1]: https://github.com/sqitchers/sqitch/releases/tag/v1.4.1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a simple Docker container that contains [sqitch][], [pgTAP][], and
 to work with `sqitch` and `pg_prove`/`pgTAP` without going through the effort of
 installing them on various systems.
 
-The image is based on Alpine 3.18 and does not include a PostgreSQL server;
+The image is based on Alpine 3.19 and does not include a PostgreSQL server;
 instead, it is expected that all values will be provided through environment
 variables or on the command-line.
 
@@ -16,39 +16,68 @@ This version of the container includes:
 - pgTAP 1.3.3 (from theory/pgtap@02bc769c92c48d01e4c2f76db6523287017b45a9)
   - Support for PostgreSQL 9.6, 10, 11, 12, 13, 14, 15, and 16
 - pg_prove 3.36
-- Sqitch 1.4.0
+- Sqitch 1.4.1
 
 The version of pgTAP is installed and uninstalled as needed; unit test files
 _**must not**_ include `CREATE EXTENSION pgtap`.
 
 These images can be pulled either from Docker Hub
-(`kineticcafe/sqitch-pgtap:2.4`) or the GitHub Container Registry
-(`ghcr.io/kineticcafe/sqitch-pgtap:2.4`).
+(`kineticcafe/sqitch-pgtap:2.5`) or the GitHub Container Registry
+(`ghcr.io/kineticcafe/sqitch-pgtap:2.5`).
 
-## `run` script Commands
+## `kineticcafe-sqitch-pgtap` script Commands
 
-The `run` script is recommended for running everything as it manages environment
-variable configuration for each run. The `run` script will pull from
-`ghcr.io/kineticcafe/sqitch-pgtap:2` by default; this can be overridden by
-using `$IMAGE`:
+The `kineticcafe-sqitch-pgtap` script is recommended for running everything as
+it manages environment variable configuration for each run. The
+`kineticcafe-sqitch-pgtap` script will pull from
+`ghcr.io/kineticcafe/sqitch-pgtap:2` by default; this can be overridden by using
+`$IMAGE`:
 
 ```console
 $ IMAGE=kineticcafe/sqitch-pgtap:latest ./run version
 [gchr.io/]kineticcafe/sqitch-pgtap:2.5.0
 
-  alpine 3.18
-  sqitch (App::Sqitch) v1.4.0
+  alpine 3.19
+  sqitch (App::Sqitch) v1.4.1
   pgtap 1.3.1
   pg_prove 3.36
 ```
 
+### Installing `kineticcafe-sqitch-pgtap`
+
+`kineticcafe-sqitch-pgtap` can be installed with symlinks using the `install`
+script:
+
+```sh
+curl -sSL --fail \
+  https://raw.githubusercontent.com/KineticCafe/docker-sqitch-pgtap/main/install |
+  bash -s -- ~/.local/bin
+```
+
+Replace `~/.local/bin` with your preferred binary directory.
+
+By default, it will download `kineticcafe-sqitch-pgtap` from GitHub and install
+it in the provided `TARGET` and make symbolic links for the following commands:
+`sqitch`, `sqitcher`, and `pgtap`. Symbolic link creation will not overwrite
+files or symbolic links to locations _other_ than `TARGET/kinetic-sqitch-pgtap`.
+
+`sqitcher` is just short name for `kineticcafe-sqitch-pgtap`.
+
+`--no-symlinks` (`-S`) may be specified to skip symbolic link creation entirely.
+
+`--force` (`-f`) may be specified to install `kineticcafe-sqitch-pgtap` even if
+it already exists, and to overwrite files and
+non-`TARGET/kineticcafe-sqitch-pgtap` symbolic links.
+
+`--verbose` (`-v`) will turn on trace output of commands.
+
 ### Core commands
 
-- `sqitch`: Runs sqitch
-- `pg_prove`: Runs pg_prove directly
+- `sqitch`: Runs Sqitch
+- `pg_prove`: Runs `pg_prove` directly
 - `pgtap install`: Installs pgTAP in the current database
 - `pgtap uninstall`: Uninstalls pgTAP from the current database
-- `pgtap test`: Installs pgTAP, runs pg_prove, and then uninstalls pgTAP
+- `pgtap test`: Installs pgTAP, runs `pg_prove`, and then uninstalls pgTAP
 - `version`: Prints the versions of the applications
 
 ### PostgreSQL commands
@@ -86,10 +115,7 @@ $ IMAGE=kineticcafe/sqitch-pgtap:latest ./run version
 - `pgtap-tests`: Runs `pgtap test test/*.sql` for the default database
 
 [`pg_prove`]: https://pgtap.org/pg_prove.html
-[disaykin/pgtap-docker-image]: https://github.com/disaykin/pgtap-docker-image
-[docker-sqitch]: https://github.com/sqitchers/docker-sqitch
-[lren-chuv/docker-pgtap]: https://github.com/LREN-CHUV/docker-pgtap
 [pgtap]: https://pgtap.org
+[pgxn]: https://pgxn.org/dist/pgtap/
 [sqitch]: https://sqitch.org
 [theory/tap-parser-sourcehandler-pgtap]: https://github.com/theory/tap-parser-sourcehandler-pgtap
-[pgxn]: https://pgxn.org/dist/pgtap/

--- a/build/pgtap/Dockerfile
+++ b/build/pgtap/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM postgres:16-alpine3.18 AS build-pgtap-psql-16
+FROM postgres:16-alpine3.19 AS build-pgtap-psql-16
 
 ARG PGTAP_VERSION
 
@@ -46,7 +46,7 @@ mv sql/pgtap.sql sql/uninstall_pgtap.sql /opt/pgtap/16
 BUILD
 
 
-FROM postgres:15-alpine3.18 AS build-pgtap-psql-15
+FROM postgres:15-alpine3.19 AS build-pgtap-psql-15
 
 ARG PGTAP_VERSION
 
@@ -92,7 +92,7 @@ mv sql/pgtap.sql sql/uninstall_pgtap.sql /opt/pgtap/15
 BUILD
 
 
-FROM postgres:14-alpine3.18 AS build-pgtap-psql-14
+FROM postgres:14-alpine3.19 AS build-pgtap-psql-14
 
 ARG PGTAP_VERSION
 
@@ -138,7 +138,7 @@ mv sql/pgtap.sql sql/uninstall_pgtap.sql /opt/pgtap/14
 BUILD
 
 
-FROM postgres:13-alpine3.18 AS build-pgtap-psql-13
+FROM postgres:13-alpine3.19 AS build-pgtap-psql-13
 
 ARG PGTAP_VERSION
 
@@ -184,7 +184,7 @@ mv sql/pgtap.sql sql/uninstall_pgtap.sql /opt/pgtap/13
 BUILD
 
 
-FROM postgres:12-alpine3.18 AS build-pgtap-psql-12
+FROM postgres:12-alpine3.19 AS build-pgtap-psql-12
 
 ARG PGTAP_VERSION
 
@@ -230,7 +230,7 @@ mv sql/pgtap.sql sql/uninstall_pgtap.sql /opt/pgtap/12
 BUILD
 
 
-FROM postgres:11-alpine3.18 AS build-pgtap-psql-11
+FROM postgres:11-alpine3.19 AS build-pgtap-psql-11
 
 ARG PGTAP_VERSION
 
@@ -368,7 +368,7 @@ mv sql/pgtap.sql sql/uninstall_pgtap.sql /opt/pgtap/9.6
 BUILD
 
 
-FROM alpine:3.18 AS package-pgtap
+FROM alpine:3.19 AS package-pgtap
 
 RUN mkdir -p /opt/pgtap
 

--- a/build/pgtap/versions.json
+++ b/build/pgtap/versions.json
@@ -1,6 +1,6 @@
 {
   "defaults": {
-    "alpine": "3.18"
+    "alpine": "3.19"
   },
   "postgres": [
     {

--- a/install
+++ b/install
@@ -1,0 +1,144 @@
+#! /usr/bin/env bash
+
+readonly url=https://raw.githubusercontent.com/KineticCafe/docker-sqitch-pgtap/main/kineticcafe-sqitch-pgtap
+declare script
+script="$(basename "${url}")"
+readonly script
+
+declare -a symlinked_commands
+symlinked_commands=(
+  sqitch sqitcher pg_prove
+)
+readonly symlinked_commands
+
+# cross-platform equivalent to GNU readlink -f.
+canonicalize() {
+  local t
+  t="$1"
+
+  cd "$(dirname "${t}")" || return 1
+  t="$(basename "${t}")"
+
+  while [[ -L "${t}" ]]; do
+    t="$(readlink "${t}")"
+    cd "$(dirname "${t}")" || return 1
+    t="$(basename "${t}")"
+  done
+
+  echo "$(pwd -P)/${t}"
+}
+
+usage() {
+  cat <<USAGE
+usage: $(basename "$0") [--no-symlinks|-S] [--force|-f] [--verbose|-v] TARGET
+       $(basename "$0") --help | -h | -?
+
+Installs the ${script} script to TARGET. Installation will be skipped
+if the TARGET/${script} already exists and --force is not supplied.
+
+Unless --no-symlinks is provided, it will also attempt to install symlinks for
+the following commands:
+
+  sqitch                    sqitcher                 pg_prove
+
+Symlink installation will be skipped if the file already exists and is not
+already a symlink to TARGET/${script} and --force is not supplied.
+USAGE
+}
+
+declare force install_symlinks no_download target target_script verbose
+force=false
+install_symlinks=true
+no_download=false
+verbose=false
+
+while (($#)); do
+  case "$1" in
+  --force | -f) force=true ;;
+  --verbose | -v) verbose=true ;;
+  --no-download) no_download=true ;;
+  --no-symlinks | -S) install_symlinks=false ;;
+  --help | -h | -?)
+    usage
+    exit 0
+    ;;
+  *)
+    if [[ ! -d "$1" ]]; then
+      printf >&2 "error: '%s' is not a directory\n\n" "$1"
+      usage >&2
+      exit 1
+    fi
+
+    if [[ -n "${target}" ]]; then
+      printf >&2 "warning: target '%s' is being replaced with '%s'" \
+        "$target" "$1"
+    fi
+
+    target="$1"
+    ;;
+  esac
+
+  shift
+done
+
+if [[ -z "${target}" ]]; then
+  printf >&2 "error: no TARGET provided\n\n"
+  usage >&2
+  exit 1
+fi
+
+target_script="${target}/${script}"
+
+download-script() {
+  local -a cmd
+  cmd=(curl -sSL --fail "${url}" -o "${target_script}")
+
+  [[ "${verbose}" ]] && echo "${cmd[*]}"
+
+  if ! "${cmd[@]}"; then
+    echo >&2 "error: could not download ${url} into ${target_script}."
+    exit 1
+  fi
+}
+
+if "${no_download}" && ! [[ -x "${target_script}" ]]; then
+  echo >&2 "error: ${target_script} does not exist and no download is set."
+  exit 1
+elif [[ -x "${target_script}" ]] && ! "${force}"; then
+  echo >&2 "error: ${target_script} already exists."
+  exit 1
+fi
+
+if ! [[ -x "${target_script}" ]] && ! "${no_download}"; then
+  download-script
+
+  if ! [[ -x "${target_script}" ]]; then
+    if "${verbose}"; then
+      chmod -v +x "${target_script}"
+    else
+      chmod +x "${target_script}"
+    fi
+  fi
+fi
+
+"${install_symlinks}" || exit 0
+
+declare symlinked_command target_command canonical_target
+
+for symlinked_command in "${symlinked_commands[@]}"; do
+  target_command="${target}/${symlinked_command}"
+
+  if [[ -f "${target_command}" ]]; then
+    canonical_target="$(canonicalize "${target_command}")"
+
+    if [[ "${canonical_target}" != "${target_script}" ]]; then
+      "${force}" || continue
+    fi
+  fi
+
+  if "${verbose}"; then
+    ln -sfv "${target_script}" "${target_command}"
+  else
+    ln -sf "${target_script}" "${target_command}"
+  fi
+done

--- a/kineticcafe-sqitch-pgtap
+++ b/kineticcafe-sqitch-pgtap
@@ -557,7 +557,9 @@ while (($#)); do
   shift
 done
 
-[[ -t 0 ]] || interactive=()
+if ! [[ -t 0 ]] || ! [[ -t 1 ]]; then
+  interactive=()
+fi
 
 if has-function "run-${cmd}"; then
   setup

--- a/package-versions.json
+++ b/package-versions.json
@@ -1,1 +1,1 @@
-{"alpine":{"version":"3.18"},"pg_prove":{"version":"3.36"},"pgtap":{"version":"1.3.3","hashref":"02bc769c92c48d01e4c2f76db6523287017b45a9"},"sqitch":{"version":"1.4.0"},"VERSION":"2.5.1"}
+{"alpine":{"version":"3.19"},"pg_prove":{"version":"3.36"},"pgtap":{"version":"1.3.3","hashref":"02bc769c92c48d01e4c2f76db6523287017b45a9"},"sqitch":{"version":"1.4.1"},"VERSION":"2.6.0"}


### PR DESCRIPTION
- Upgrade Sqitch to version [1.4.1][sqitch-1.4.1].

- Upgrade Alpine to version [3.19][alpine-3.19].

- Rename `run` to `kineticcafe-sqitch-pgtap`.

- Added an `install` script to install `kineticcafe-sqitch-pgtap` and
  optional symlinks.
