### PR TITLE
hotfix: Upgrade to pgTAP 1.3.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # kineticcafe/sqitch-pgtap Changelog
 
+## 2.5.1 / 2024-02-20
+
+- Upgrade pgTAP to 1.3.3 at
+  theory/pgtap@02bc769c92c48d01e4c2f76db6523287017b45a9. This fixes a bug
+  introduced where the column type validation is reporting invalid values.
+  Incorporates the fix theory/pgtap#332.
+
 ## 2.5.0 / 2023-09-27
 
 - Upgraded pgTAP to 1.3.1.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ The image is based on Alpine 3.18 and does not include a PostgreSQL server;
 instead, it is expected that all values will be provided through environment
 variables or on the command-line.
 
+Unless otherwise noted, pgTAP will be installed from [PGXN][].
+
 This version of the container includes:
 
-- pgTAP 1.3.1 (from [PGXN][])
+- pgTAP 1.3.3 (from theory/pgtap@02bc769c92c48d01e4c2f76db6523287017b45a9)
   - Support for PostgreSQL 9.6, 10, 11, 12, 13, 14, 15, and 16
 - pg_prove 3.36
 - Sqitch 1.4.0

--- a/opt/pgtap/10/pgtap.sql
+++ b/opt/pgtap/10/pgtap.sql
@@ -22,11 +22,6 @@ CREATE OR REPLACE FUNCTION pgtap_version()
 RETURNS NUMERIC AS 'SELECT 1.3;'
 LANGUAGE SQL IMMUTABLE;
 
-CREATE FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4)
-RETURNS RECORD
-AS '$libdir/pgtap'
-LANGUAGE C STABLE STRICT;
-
 CREATE OR REPLACE FUNCTION plan( integer )
 RETURNS TEXT AS $$
 DECLARE
@@ -1468,7 +1463,33 @@ $$ LANGUAGE PLPGSQL STABLE;
 
 CREATE OR REPLACE FUNCTION format_type_string ( TEXT )
 RETURNS TEXT AS $$
-BEGIN RETURN format_type(p.typid, p.typmod) from parse_type($1) p;
+DECLARE
+    want_type TEXT := $1;
+    typmodin_arg cstring[];
+    typmodin_func regproc;
+    typmod int;
+BEGIN
+    IF want_type::regtype = 'interval'::regtype THEN
+        -- RAISE NOTICE 'cannot resolve: %', want_type;  -- TODO
+        RETURN want_type;
+    END IF;
+
+    -- Extract type modifier from type declaration and format as cstring[] literal.
+    typmodin_arg := translate(substring(want_type FROM '[(][^")]+[)]'), '()', '{}');
+
+    -- Find typmodin function for want_type.
+    SELECT typmodin INTO typmodin_func
+      FROM pg_catalog.pg_type
+     WHERE oid = want_type::regtype;
+
+    IF typmodin_func = 0 THEN
+        -- Easy: types without typemods.
+        RETURN format_type(want_type::regtype, null);
+    END IF;
+
+    -- Get typemod via type-specific typmodin function.
+    EXECUTE format('SELECT %s(%L)', typmodin_func, typmodin_arg) INTO typmod;
+    RETURN format_type(want_type::regtype, typmod);
 EXCEPTION WHEN OTHERS THEN RETURN NULL;
 END;
 $$ LANGUAGE PLPGSQL STABLE;

--- a/opt/pgtap/10/uninstall_pgtap.sql
+++ b/opt/pgtap/10/uninstall_pgtap.sql
@@ -1076,7 +1076,6 @@ DROP FUNCTION IF EXISTS _get_latest ( text );
 DROP FUNCTION IF EXISTS _get ( text );
 DROP FUNCTION IF EXISTS no_plan();
 DROP FUNCTION IF EXISTS plan( integer );
-DROP FUNCTION IF EXISTS parse_type(type text, OUT typid oid, OUT typmod int4);
 DROP FUNCTION IF EXISTS pgtap_version();
 DROP FUNCTION IF EXISTS os_name();
 DROP FUNCTION IF EXISTS pg_version_num();

--- a/opt/pgtap/11/pgtap.sql
+++ b/opt/pgtap/11/pgtap.sql
@@ -22,11 +22,6 @@ CREATE OR REPLACE FUNCTION pgtap_version()
 RETURNS NUMERIC AS 'SELECT 1.3;'
 LANGUAGE SQL IMMUTABLE;
 
-CREATE FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4)
-RETURNS RECORD
-AS '$libdir/pgtap'
-LANGUAGE C STABLE STRICT;
-
 CREATE OR REPLACE FUNCTION plan( integer )
 RETURNS TEXT AS $$
 DECLARE
@@ -1468,7 +1463,33 @@ $$ LANGUAGE PLPGSQL STABLE;
 
 CREATE OR REPLACE FUNCTION format_type_string ( TEXT )
 RETURNS TEXT AS $$
-BEGIN RETURN format_type(p.typid, p.typmod) from parse_type($1) p;
+DECLARE
+    want_type TEXT := $1;
+    typmodin_arg cstring[];
+    typmodin_func regproc;
+    typmod int;
+BEGIN
+    IF want_type::regtype = 'interval'::regtype THEN
+        -- RAISE NOTICE 'cannot resolve: %', want_type;  -- TODO
+        RETURN want_type;
+    END IF;
+
+    -- Extract type modifier from type declaration and format as cstring[] literal.
+    typmodin_arg := translate(substring(want_type FROM '[(][^")]+[)]'), '()', '{}');
+
+    -- Find typmodin function for want_type.
+    SELECT typmodin INTO typmodin_func
+      FROM pg_catalog.pg_type
+     WHERE oid = want_type::regtype;
+
+    IF typmodin_func = 0 THEN
+        -- Easy: types without typemods.
+        RETURN format_type(want_type::regtype, null);
+    END IF;
+
+    -- Get typemod via type-specific typmodin function.
+    EXECUTE format('SELECT %s(%L)', typmodin_func, typmodin_arg) INTO typmod;
+    RETURN format_type(want_type::regtype, typmod);
 EXCEPTION WHEN OTHERS THEN RETURN NULL;
 END;
 $$ LANGUAGE PLPGSQL STABLE;

--- a/opt/pgtap/11/uninstall_pgtap.sql
+++ b/opt/pgtap/11/uninstall_pgtap.sql
@@ -1076,7 +1076,6 @@ DROP FUNCTION IF EXISTS _get_latest ( text );
 DROP FUNCTION IF EXISTS _get ( text );
 DROP FUNCTION IF EXISTS no_plan();
 DROP FUNCTION IF EXISTS plan( integer );
-DROP FUNCTION IF EXISTS parse_type(type text, OUT typid oid, OUT typmod int4);
 DROP FUNCTION IF EXISTS pgtap_version();
 DROP FUNCTION IF EXISTS os_name();
 DROP FUNCTION IF EXISTS pg_version_num();

--- a/opt/pgtap/12/pgtap.sql
+++ b/opt/pgtap/12/pgtap.sql
@@ -22,11 +22,6 @@ CREATE OR REPLACE FUNCTION pgtap_version()
 RETURNS NUMERIC AS 'SELECT 1.3;'
 LANGUAGE SQL IMMUTABLE;
 
-CREATE FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4)
-RETURNS RECORD
-AS '$libdir/pgtap'
-LANGUAGE C STABLE STRICT;
-
 CREATE OR REPLACE FUNCTION plan( integer )
 RETURNS TEXT AS $$
 DECLARE
@@ -1468,7 +1463,33 @@ $$ LANGUAGE PLPGSQL STABLE;
 
 CREATE OR REPLACE FUNCTION format_type_string ( TEXT )
 RETURNS TEXT AS $$
-BEGIN RETURN format_type(p.typid, p.typmod) from parse_type($1) p;
+DECLARE
+    want_type TEXT := $1;
+    typmodin_arg cstring[];
+    typmodin_func regproc;
+    typmod int;
+BEGIN
+    IF want_type::regtype = 'interval'::regtype THEN
+        -- RAISE NOTICE 'cannot resolve: %', want_type;  -- TODO
+        RETURN want_type;
+    END IF;
+
+    -- Extract type modifier from type declaration and format as cstring[] literal.
+    typmodin_arg := translate(substring(want_type FROM '[(][^")]+[)]'), '()', '{}');
+
+    -- Find typmodin function for want_type.
+    SELECT typmodin INTO typmodin_func
+      FROM pg_catalog.pg_type
+     WHERE oid = want_type::regtype;
+
+    IF typmodin_func = 0 THEN
+        -- Easy: types without typemods.
+        RETURN format_type(want_type::regtype, null);
+    END IF;
+
+    -- Get typemod via type-specific typmodin function.
+    EXECUTE format('SELECT %s(%L)', typmodin_func, typmodin_arg) INTO typmod;
+    RETURN format_type(want_type::regtype, typmod);
 EXCEPTION WHEN OTHERS THEN RETURN NULL;
 END;
 $$ LANGUAGE PLPGSQL STABLE;

--- a/opt/pgtap/12/uninstall_pgtap.sql
+++ b/opt/pgtap/12/uninstall_pgtap.sql
@@ -1076,7 +1076,6 @@ DROP FUNCTION IF EXISTS _get_latest ( text );
 DROP FUNCTION IF EXISTS _get ( text );
 DROP FUNCTION IF EXISTS no_plan();
 DROP FUNCTION IF EXISTS plan( integer );
-DROP FUNCTION IF EXISTS parse_type(type text, OUT typid oid, OUT typmod int4);
 DROP FUNCTION IF EXISTS pgtap_version();
 DROP FUNCTION IF EXISTS os_name();
 DROP FUNCTION IF EXISTS pg_version_num();

--- a/opt/pgtap/13/pgtap.sql
+++ b/opt/pgtap/13/pgtap.sql
@@ -22,11 +22,6 @@ CREATE OR REPLACE FUNCTION pgtap_version()
 RETURNS NUMERIC AS 'SELECT 1.3;'
 LANGUAGE SQL IMMUTABLE;
 
-CREATE FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4)
-RETURNS RECORD
-AS '$libdir/pgtap'
-LANGUAGE C STABLE STRICT;
-
 CREATE OR REPLACE FUNCTION plan( integer )
 RETURNS TEXT AS $$
 DECLARE
@@ -1468,7 +1463,33 @@ $$ LANGUAGE PLPGSQL STABLE;
 
 CREATE OR REPLACE FUNCTION format_type_string ( TEXT )
 RETURNS TEXT AS $$
-BEGIN RETURN format_type(p.typid, p.typmod) from parse_type($1) p;
+DECLARE
+    want_type TEXT := $1;
+    typmodin_arg cstring[];
+    typmodin_func regproc;
+    typmod int;
+BEGIN
+    IF want_type::regtype = 'interval'::regtype THEN
+        -- RAISE NOTICE 'cannot resolve: %', want_type;  -- TODO
+        RETURN want_type;
+    END IF;
+
+    -- Extract type modifier from type declaration and format as cstring[] literal.
+    typmodin_arg := translate(substring(want_type FROM '[(][^")]+[)]'), '()', '{}');
+
+    -- Find typmodin function for want_type.
+    SELECT typmodin INTO typmodin_func
+      FROM pg_catalog.pg_type
+     WHERE oid = want_type::regtype;
+
+    IF typmodin_func = 0 THEN
+        -- Easy: types without typemods.
+        RETURN format_type(want_type::regtype, null);
+    END IF;
+
+    -- Get typemod via type-specific typmodin function.
+    EXECUTE format('SELECT %s(%L)', typmodin_func, typmodin_arg) INTO typmod;
+    RETURN format_type(want_type::regtype, typmod);
 EXCEPTION WHEN OTHERS THEN RETURN NULL;
 END;
 $$ LANGUAGE PLPGSQL STABLE;

--- a/opt/pgtap/13/uninstall_pgtap.sql
+++ b/opt/pgtap/13/uninstall_pgtap.sql
@@ -1076,7 +1076,6 @@ DROP FUNCTION IF EXISTS _get_latest ( text );
 DROP FUNCTION IF EXISTS _get ( text );
 DROP FUNCTION IF EXISTS no_plan();
 DROP FUNCTION IF EXISTS plan( integer );
-DROP FUNCTION IF EXISTS parse_type(type text, OUT typid oid, OUT typmod int4);
 DROP FUNCTION IF EXISTS pgtap_version();
 DROP FUNCTION IF EXISTS os_name();
 DROP FUNCTION IF EXISTS pg_version_num();

--- a/opt/pgtap/14/pgtap.sql
+++ b/opt/pgtap/14/pgtap.sql
@@ -22,11 +22,6 @@ CREATE OR REPLACE FUNCTION pgtap_version()
 RETURNS NUMERIC AS 'SELECT 1.3;'
 LANGUAGE SQL IMMUTABLE;
 
-CREATE FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4)
-RETURNS RECORD
-AS '$libdir/pgtap'
-LANGUAGE C STABLE STRICT;
-
 CREATE OR REPLACE FUNCTION plan( integer )
 RETURNS TEXT AS $$
 DECLARE
@@ -1468,7 +1463,33 @@ $$ LANGUAGE PLPGSQL STABLE;
 
 CREATE OR REPLACE FUNCTION format_type_string ( TEXT )
 RETURNS TEXT AS $$
-BEGIN RETURN format_type(p.typid, p.typmod) from parse_type($1) p;
+DECLARE
+    want_type TEXT := $1;
+    typmodin_arg cstring[];
+    typmodin_func regproc;
+    typmod int;
+BEGIN
+    IF want_type::regtype = 'interval'::regtype THEN
+        -- RAISE NOTICE 'cannot resolve: %', want_type;  -- TODO
+        RETURN want_type;
+    END IF;
+
+    -- Extract type modifier from type declaration and format as cstring[] literal.
+    typmodin_arg := translate(substring(want_type FROM '[(][^")]+[)]'), '()', '{}');
+
+    -- Find typmodin function for want_type.
+    SELECT typmodin INTO typmodin_func
+      FROM pg_catalog.pg_type
+     WHERE oid = want_type::regtype;
+
+    IF typmodin_func = 0 THEN
+        -- Easy: types without typemods.
+        RETURN format_type(want_type::regtype, null);
+    END IF;
+
+    -- Get typemod via type-specific typmodin function.
+    EXECUTE format('SELECT %s(%L)', typmodin_func, typmodin_arg) INTO typmod;
+    RETURN format_type(want_type::regtype, typmod);
 EXCEPTION WHEN OTHERS THEN RETURN NULL;
 END;
 $$ LANGUAGE PLPGSQL STABLE;

--- a/opt/pgtap/14/uninstall_pgtap.sql
+++ b/opt/pgtap/14/uninstall_pgtap.sql
@@ -1076,7 +1076,6 @@ DROP FUNCTION IF EXISTS _get_latest ( text );
 DROP FUNCTION IF EXISTS _get ( text );
 DROP FUNCTION IF EXISTS no_plan();
 DROP FUNCTION IF EXISTS plan( integer );
-DROP FUNCTION IF EXISTS parse_type(type text, OUT typid oid, OUT typmod int4);
 DROP FUNCTION IF EXISTS pgtap_version();
 DROP FUNCTION IF EXISTS os_name();
 DROP FUNCTION IF EXISTS pg_version_num();

--- a/opt/pgtap/15/pgtap.sql
+++ b/opt/pgtap/15/pgtap.sql
@@ -22,11 +22,6 @@ CREATE OR REPLACE FUNCTION pgtap_version()
 RETURNS NUMERIC AS 'SELECT 1.3;'
 LANGUAGE SQL IMMUTABLE;
 
-CREATE FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4)
-RETURNS RECORD
-AS '$libdir/pgtap'
-LANGUAGE C STABLE STRICT;
-
 CREATE OR REPLACE FUNCTION plan( integer )
 RETURNS TEXT AS $$
 DECLARE
@@ -1468,7 +1463,33 @@ $$ LANGUAGE PLPGSQL STABLE;
 
 CREATE OR REPLACE FUNCTION format_type_string ( TEXT )
 RETURNS TEXT AS $$
-BEGIN RETURN format_type(p.typid, p.typmod) from parse_type($1) p;
+DECLARE
+    want_type TEXT := $1;
+    typmodin_arg cstring[];
+    typmodin_func regproc;
+    typmod int;
+BEGIN
+    IF want_type::regtype = 'interval'::regtype THEN
+        -- RAISE NOTICE 'cannot resolve: %', want_type;  -- TODO
+        RETURN want_type;
+    END IF;
+
+    -- Extract type modifier from type declaration and format as cstring[] literal.
+    typmodin_arg := translate(substring(want_type FROM '[(][^")]+[)]'), '()', '{}');
+
+    -- Find typmodin function for want_type.
+    SELECT typmodin INTO typmodin_func
+      FROM pg_catalog.pg_type
+     WHERE oid = want_type::regtype;
+
+    IF typmodin_func = 0 THEN
+        -- Easy: types without typemods.
+        RETURN format_type(want_type::regtype, null);
+    END IF;
+
+    -- Get typemod via type-specific typmodin function.
+    EXECUTE format('SELECT %s(%L)', typmodin_func, typmodin_arg) INTO typmod;
+    RETURN format_type(want_type::regtype, typmod);
 EXCEPTION WHEN OTHERS THEN RETURN NULL;
 END;
 $$ LANGUAGE PLPGSQL STABLE;

--- a/opt/pgtap/15/uninstall_pgtap.sql
+++ b/opt/pgtap/15/uninstall_pgtap.sql
@@ -1076,7 +1076,6 @@ DROP FUNCTION IF EXISTS _get_latest ( text );
 DROP FUNCTION IF EXISTS _get ( text );
 DROP FUNCTION IF EXISTS no_plan();
 DROP FUNCTION IF EXISTS plan( integer );
-DROP FUNCTION IF EXISTS parse_type(type text, OUT typid oid, OUT typmod int4);
 DROP FUNCTION IF EXISTS pgtap_version();
 DROP FUNCTION IF EXISTS os_name();
 DROP FUNCTION IF EXISTS pg_version_num();

--- a/opt/pgtap/16/pgtap.sql
+++ b/opt/pgtap/16/pgtap.sql
@@ -22,11 +22,6 @@ CREATE OR REPLACE FUNCTION pgtap_version()
 RETURNS NUMERIC AS 'SELECT 1.3;'
 LANGUAGE SQL IMMUTABLE;
 
-CREATE FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4)
-RETURNS RECORD
-AS '$libdir/pgtap'
-LANGUAGE C STABLE STRICT;
-
 CREATE OR REPLACE FUNCTION plan( integer )
 RETURNS TEXT AS $$
 DECLARE
@@ -1468,7 +1463,33 @@ $$ LANGUAGE PLPGSQL STABLE;
 
 CREATE OR REPLACE FUNCTION format_type_string ( TEXT )
 RETURNS TEXT AS $$
-BEGIN RETURN format_type(p.typid, p.typmod) from parse_type($1) p;
+DECLARE
+    want_type TEXT := $1;
+    typmodin_arg cstring[];
+    typmodin_func regproc;
+    typmod int;
+BEGIN
+    IF want_type::regtype = 'interval'::regtype THEN
+        -- RAISE NOTICE 'cannot resolve: %', want_type;  -- TODO
+        RETURN want_type;
+    END IF;
+
+    -- Extract type modifier from type declaration and format as cstring[] literal.
+    typmodin_arg := translate(substring(want_type FROM '[(][^")]+[)]'), '()', '{}');
+
+    -- Find typmodin function for want_type.
+    SELECT typmodin INTO typmodin_func
+      FROM pg_catalog.pg_type
+     WHERE oid = want_type::regtype;
+
+    IF typmodin_func = 0 THEN
+        -- Easy: types without typemods.
+        RETURN format_type(want_type::regtype, null);
+    END IF;
+
+    -- Get typemod via type-specific typmodin function.
+    EXECUTE format('SELECT %s(%L)', typmodin_func, typmodin_arg) INTO typmod;
+    RETURN format_type(want_type::regtype, typmod);
 EXCEPTION WHEN OTHERS THEN RETURN NULL;
 END;
 $$ LANGUAGE PLPGSQL STABLE;

--- a/opt/pgtap/16/uninstall_pgtap.sql
+++ b/opt/pgtap/16/uninstall_pgtap.sql
@@ -1076,7 +1076,6 @@ DROP FUNCTION IF EXISTS _get_latest ( text );
 DROP FUNCTION IF EXISTS _get ( text );
 DROP FUNCTION IF EXISTS no_plan();
 DROP FUNCTION IF EXISTS plan( integer );
-DROP FUNCTION IF EXISTS parse_type(type text, OUT typid oid, OUT typmod int4);
 DROP FUNCTION IF EXISTS pgtap_version();
 DROP FUNCTION IF EXISTS os_name();
 DROP FUNCTION IF EXISTS pg_version_num();

--- a/opt/pgtap/9.6/pgtap.sql
+++ b/opt/pgtap/9.6/pgtap.sql
@@ -22,11 +22,6 @@ CREATE OR REPLACE FUNCTION pgtap_version()
 RETURNS NUMERIC AS 'SELECT 1.3;'
 LANGUAGE SQL IMMUTABLE;
 
-CREATE FUNCTION parse_type(type text, OUT typid oid, OUT typmod int4)
-RETURNS RECORD
-AS '$libdir/pgtap'
-LANGUAGE C STABLE STRICT;
-
 CREATE OR REPLACE FUNCTION plan( integer )
 RETURNS TEXT AS $$
 DECLARE
@@ -1468,7 +1463,33 @@ $$ LANGUAGE PLPGSQL STABLE;
 
 CREATE OR REPLACE FUNCTION format_type_string ( TEXT )
 RETURNS TEXT AS $$
-BEGIN RETURN format_type(p.typid, p.typmod) from parse_type($1) p;
+DECLARE
+    want_type TEXT := $1;
+    typmodin_arg cstring[];
+    typmodin_func regproc;
+    typmod int;
+BEGIN
+    IF want_type::regtype = 'interval'::regtype THEN
+        -- RAISE NOTICE 'cannot resolve: %', want_type;  -- TODO
+        RETURN want_type;
+    END IF;
+
+    -- Extract type modifier from type declaration and format as cstring[] literal.
+    typmodin_arg := translate(substring(want_type FROM '[(][^")]+[)]'), '()', '{}');
+
+    -- Find typmodin function for want_type.
+    SELECT typmodin INTO typmodin_func
+      FROM pg_catalog.pg_type
+     WHERE oid = want_type::regtype;
+
+    IF typmodin_func = 0 THEN
+        -- Easy: types without typemods.
+        RETURN format_type(want_type::regtype, null);
+    END IF;
+
+    -- Get typemod via type-specific typmodin function.
+    EXECUTE format('SELECT %s(%L)', typmodin_func, typmodin_arg) INTO typmod;
+    RETURN format_type(want_type::regtype, typmod);
 EXCEPTION WHEN OTHERS THEN RETURN NULL;
 END;
 $$ LANGUAGE PLPGSQL STABLE;

--- a/opt/pgtap/9.6/uninstall_pgtap.sql
+++ b/opt/pgtap/9.6/uninstall_pgtap.sql
@@ -1064,7 +1064,6 @@ DROP FUNCTION IF EXISTS _get_latest ( text );
 DROP FUNCTION IF EXISTS _get ( text );
 DROP FUNCTION IF EXISTS no_plan();
 DROP FUNCTION IF EXISTS plan( integer );
-DROP FUNCTION IF EXISTS parse_type(type text, OUT typid oid, OUT typmod int4);
 DROP FUNCTION IF EXISTS pgtap_version();
 DROP FUNCTION IF EXISTS os_name();
 DROP FUNCTION IF EXISTS pg_version_num();

--- a/package-versions.json
+++ b/package-versions.json
@@ -1,1 +1,1 @@
-{"alpine":{"version":"3.18"},"pg_prove":{"version":"3.36"},"pgtap":{"version":"1.3.1"},"sqitch":{"version":"1.4.0"},"VERSION":"2.5.0"}
+{"alpine":{"version":"3.18"},"pg_prove":{"version":"3.36"},"pgtap":{"version":"1.3.3","hashref":"02bc769c92c48d01e4c2f76db6523287017b45a9"},"sqitch":{"version":"1.4.0"},"VERSION":"2.5.1"}


### PR DESCRIPTION
- Upgrade pgTAP to 1.3.3 at
  theory/pgtap@02bc769c92c48d01e4c2f76db6523287017b45a9. This fixes a bug
  introduced where the column type validation is reporting invalid values.