### PR TITLE
Improved release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           ref: refs/tags/${{ github.event.inputs.tag }}
 
+      - run: |
+          echo REPOSITORY="$(
+            echo "${GITHUB_REPOSITORY}" |
+              tr '[:upper:]' '[:lower:]' |
+              sed 's/docker-//'
+          )" >"${GITHUB_ENV}"
+
       - uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -37,8 +44,8 @@ jobs:
         uses: docker/metadata-action@v5.5.1
         with:
           images: |
-            kineticcafe/sqitch-pgtap
-            ghcr.io/kineticcafe/sqitch-pgtap
+            ${{ env.REPOSITORY }}
+            ghcr.io/${{ env.REPOSITORY }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
@@ -50,7 +57,7 @@ jobs:
             type=sha
 
       - uses: docker/setup-qemu-action@v3.0.0
-      - uses: docker/setup-buildx-action@v3.0.0
+      - uses: docker/setup-buildx-action@v3.1.0
 
       - id: package-versions
         run: echo "data=$(cat package-versions.json)" >> $GITHUB_OUTPUT
@@ -82,7 +89,7 @@ jobs:
 
       - uses: peter-evans/dockerhub-description@v4.0.0
         with:
-          repository: kineticcafe/sqitch-pgtap
+          repository: kineticcafe/${{ env.REPOSITORY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 


### PR DESCRIPTION
We maintain three docker images:

- ansible
- sqitch / pgTAP
- aws-cli with SessionManager plugin

The release flows are basically the same, but there were *unnecessary*
differences.

- We set `env.REPOSITORY` based on `GITHUB_REPOSITORY`, converting entirely to
  lowercase and removing the leading `docker-`.

- We use `kineticcafe/${{ env.REPOSITORY }}` for image builds and Dockerhub
  description updates.